### PR TITLE
fix: linux nvme driver admin passthru panic

### DIFF
--- a/nvme/types.go
+++ b/nvme/types.go
@@ -467,7 +467,9 @@ func (cmd *PassthruCmd) GetDataAddr() uint64 {
 func (cmd *NvmeAdminCmd) GetDataAddr() uint64 {
 	if cmd.DataAddr != 0 {
 		return uint64(cmd.DataAddr)
-	} else {
+	} else if len(cmd.DataBuffer) != 0 {
 		return uint64(uintptr(unsafe.Pointer(&cmd.DataBuffer[0])))
 	}
+
+	return 0
 }

--- a/plat_linux/nvme_driver.go
+++ b/plat_linux/nvme_driver.go
@@ -6,8 +6,9 @@ package plat_linux
 import (
 	"errors"
 	"fmt"
-	common_nvme "github.com/jc-lab/go-dparm/common/nvme"
 	"unsafe"
+
+	common_nvme "github.com/jc-lab/go-dparm/common/nvme"
 
 	"golang.org/x/sys/unix"
 
@@ -85,9 +86,6 @@ func (s *LinuxNvmeDriverHandle) DoNvmeAdminPassthru(cmd *nvme.NvmeAdminCmd) erro
 	data.Cdw3 = cmd.Cdw3
 	data.Metadata = cmd.Metadata
 	data.Addr = cmd.GetDataAddr()
-	if data.Addr == 0 {
-		return errors.New("addr is null")
-	}
 	data.MetadataLen = cmd.MetadataLen
 	data.DataLen = cmd.DataLen
 	data.Cdw10 = cmd.Cdw10

--- a/plat_linux/nvme_driver.go
+++ b/plat_linux/nvme_driver.go
@@ -118,9 +118,6 @@ func (s *LinuxNvmeDriverHandle) DoNvmeIoPassthru(cmd *nvme.PassthruCmd) error {
 	data.Cdw3 = cmd.Cdw3
 	data.Metadata = cmd.Metadata
 	data.Addr = cmd.GetDataAddr()
-	if data.Addr == 0 {
-		return errors.New("addr is null")
-	}
 	data.MetadataLen = cmd.MetadataLen
 	data.Cdw10 = cmd.Cdw10
 	data.Cdw11 = cmd.Cdw11


### PR DESCRIPTION
- allow NvmeAdminCmd.Data to be 0 as it can be used with 0 value
- check length of NvmeAdminCmd.DataBuffer to prevent panic